### PR TITLE
Revert "Limit on number of generations for worker (#6)"

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -99,7 +99,6 @@ export const config = {
         filename: 'critters-worker.js',
         // in seconds
         firstUpdate: 2,
-        generations: 1000,
         // in generations
         logInterval: 50,
         // in seconds

--- a/src/genetic.ts
+++ b/src/genetic.ts
@@ -31,13 +31,20 @@ import { Simulator, SimulatorResult } from './simulator';
 
 export class GeneticAlgorithmOrchestrator {
     private population: Genome[];
+    private generation: number;
 
     constructor(private readonly simulator: Simulator) {
         this.population = [];
+        this.generation = 0;
+    }
+
+    getGeneration(): number {
+        return this.generation;
     }
 
     start(): void {
         this.population = Genome.randomPopulation(config.geneticAlgorithm.populationSize);
+        this.generation = 0;
     }
 
     run(): SimulatorResult[] {
@@ -50,6 +57,8 @@ export class GeneticAlgorithmOrchestrator {
         const pool = this.selectPool(simResults);
 
         this.population = this.generateNextPopulation(pool);
+
+        ++this.generation;
 
         return simResults;
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -42,37 +42,28 @@ export class CrittersWorker {
 
     start(): void {
         this.logger.log('Worker is alive!');
-
-        const timeStart = performance.now();
-
         this.geneticAlgorithmOrchestrator.start();
-
         this.loop();
-
-        const timeEnd = performance.now();
-        const runTimeSeconds = (timeEnd - timeStart) / MILLISECONDS_PER_SECOND;
-
-        this.logger.log(`Worker is done after ${runTimeSeconds.toFixed(2)} seconds.`);
     }
 
     private loop(): void {
         let updateDue = performance.now() + config.worker.firstUpdate * MILLISECONDS_PER_SECOND;
 
-        for (let generation = 1; generation <= config.worker.generations; ++generation) {
+        while (true) {
             const timeStart = performance.now();
 
             const simResults = this.geneticAlgorithmOrchestrator.run();
 
             const timeEnd = performance.now();
 
-            const isLastGeneration = generation == config.worker.generations;
-
-            if (timeEnd > updateDue || isLastGeneration) {
+            if (timeEnd > updateDue) {
                 this.updateMain(simResults);
                 updateDue = timeEnd + config.worker.updateInterval * MILLISECONDS_PER_SECOND;
             }
 
-            if (generation % config.worker.logInterval == 0 || isLastGeneration) {
+            const generation = this.geneticAlgorithmOrchestrator.getGeneration();
+
+            if (generation % config.worker.logInterval == 0) {
                 this.logGeneration(simResults, generation, timeEnd - timeStart);
             }
         }


### PR DESCRIPTION
Revert PR #6.

Sometimes, the last generation isn't randomly not that great and stays that way forever. Removing the limit ensured that, if we fall on a bad solution, that situation will resolve eventually.


This reverts commit 6fd095910a041e9631a672ca8512ecb5630f0ed7.