### PR TITLE
Set AWS role duration to minimum

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -109,7 +109,6 @@ jobs:
     name: Push to ECR (public.ecr.aws)
     
     runs-on: ubuntu-latest
-    # Should match the aws-actions/configure-aws-credentials role duration
     timeout-minutes: 5
     needs: build
 
@@ -152,8 +151,8 @@ jobs:
         with:
           role-to-assume: ${{ secrets.ASSUME_ROLE_ARN }}
           role-session-name: push-ecr-${{ github.sha }}
-          # Should match the job timeout
-          role-duration-seconds: 300
+          # 900 (i.e. 15 minutes) is the minimum
+          role-duration-seconds: 900
           # Needs to be us-east-1 for ECR public
           aws-region: us-east-1
 


### PR DESCRIPTION
Set AWS assumed role duration to 900 seconds (15 minutes), which is the minimum.