### PR TITLE
Split PR check jobs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,4 @@
-name: Pull Request Checks
+name: PR Checks
 
 on:
   pull_request:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,8 +5,8 @@ on:
     branches: [ '*' ]
 
 jobs:
-  checks:
-    name: Checks
+  build:
+    name: Build
 
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -22,6 +22,18 @@ jobs:
     
     - name: Build container image
       run: docker build -t crittersjs .
+  
+  lint:
+    name: Lint
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install dependencies
+      run: npm ci
     
     - name: Lint
       run: npm run lint


### PR DESCRIPTION
Split build and lint into separate jobs in the pull request checks workflow so the reported statuses are more specific.