### PR TITLE
Filter by path in workflow trigger

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -3,6 +3,15 @@ name: Build and Deploy
 on:
   push:
     branches: [ main ]
+    paths:
+      - '.github/workflows/build-deploy.yml'
+      - 'src/**'
+      - 'static/**'
+      - 'Dockerfile'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'webpack.config.js'
 
 env:
   LOCAL_IMAGE: crittersjs


### PR DESCRIPTION
Use path filtering in the main branch workflow to ensure a build and deployment only occurs if needed.