### PR TITLE
Prepare for TypeScript 6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "es6",
-        "outDir": "./dist/",
+        "rootDir": "./src",
+        "outDir": "./dist",
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "strict": true,


### PR DESCRIPTION
* Set `rootDir` in tsconfig.json as required by TypeScript 6. The most recent Dependabot PR, which upgrades from TypeScript 5.9.3 to 6.0.2, has been failing for this reason.
* Also set the target to ES6 since ES5 is now deprecated.